### PR TITLE
Add a param for specifying the "Search In" option on audiobookbay

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ npm install audiobookbay
 import audiobookbay from "audiobookbay";
 
 const audiobooks = await audiobookbay.search("dune", 2, {
-  content: false,
-  torrent: false,
+  titleAuthor: true,
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,17 +13,21 @@ npm install audiobookbay
 
 ## 🔍 Searching for audiobooks
 
-| Name  | Description  | Default | Type   |
-| ----- | ------------ | ------- | ------ |
-| Query | Search Query |         | String |
-| Page  | Search Page  | 1       | Number |
+| Name      | Description            | Default                                               | Type   |
+| --------- | ---------------------- | ----------------------------------------------------- | ------ |
+| Query     | Search Query           |                                                       | String |
+| Page      | Search Page            | 1                                                     | Number |
+| Search In | Text content to search | `{ titleAuthor: true, content: true, torrent: true }` | Object |
 
 <br>
 
 ```js
 import audiobookbay from "audiobookbay";
 
-const audiobooks = await audiobookbay.search("dune", 2);
+const audiobooks = await audiobookbay.search("dune", 2, {
+  content: false,
+  torrent: false,
+});
 ```
 
 ### Response

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
+import { URLSearchParams } from "url";
 import getAudiobook from "@utils/getAudiobook";
 import getAudiobooks from "@utils/searchAudiobooks";
 import { Categories, Tags } from "@interface/explore";
+import { SearchIn } from "@interface/search";
+import getSearchInParam, { defaultSearchIn } from "@utils/getSearchInParam";
 
 /**
  * Search Audiobooks
@@ -9,10 +12,22 @@ import { Categories, Tags } from "@interface/explore";
  * @param page Current Page
  * @returns Audiobook List
  */
-export const search = async (query: string, page: number = 1) =>
-  await getAudiobooks(
-    `http://audiobookbay.se/page/${page}/?s=${query.toLowerCase()}`
+export const search = async (
+  query: string,
+  page: number = 1,
+  searchIn: SearchIn = defaultSearchIn
+) => {
+  const tt = getSearchInParam(searchIn);
+
+  const params = new URLSearchParams({
+    s: query.toLowerCase(),
+    tt,
+  });
+
+  return await getAudiobooks(
+    `http://audiobookbay.se/page/${page}/?${params.toString()}`
   );
+};
 
 /**
  * Get Single Audiobook

--- a/src/interface/search.ts
+++ b/src/interface/search.ts
@@ -17,3 +17,27 @@ export interface Pagination {
   totalPages: number;
   count: number;
 }
+
+/**
+ * Extra search options for what text content should be searched
+ */
+export interface SearchIn {
+  /**
+   * Search in Title and Authors fields
+   *
+   * @defaultValue true
+   */
+  titleAuthor: boolean;
+  /**
+   * Search in book page's Content
+   *
+   * @defaultValue true
+   */
+  content: boolean;
+  /**
+   * Search in the torrent's contents
+   *
+   * @defaultValue true
+   */
+  torrent: boolean;
+}

--- a/src/utils/getSearchInParam.ts
+++ b/src/utils/getSearchInParam.ts
@@ -1,0 +1,23 @@
+import { SearchIn } from "@interface/search";
+
+export const defaultSearchIn: SearchIn = {
+  titleAuthor: true,
+  content: true,
+  torrent: true,
+};
+
+const getSearchInParam = (searchIn: SearchIn = defaultSearchIn) => {
+  const realSearchIn = { ...defaultSearchIn, ...searchIn };
+
+  const tt = [
+    realSearchIn.titleAuthor ? "1" : "",
+    realSearchIn.content ? "2" : "",
+    realSearchIn.torrent ? "3" : "",
+  ]
+    .filter(Boolean)
+    .join(",");
+
+  return tt;
+};
+
+export default getSearchInParam;

--- a/src/utils/getSearchInParam.ts
+++ b/src/utils/getSearchInParam.ts
@@ -7,12 +7,10 @@ export const defaultSearchIn: SearchIn = {
 };
 
 const getSearchInParam = (searchIn: SearchIn = defaultSearchIn) => {
-  const realSearchIn = { ...defaultSearchIn, ...searchIn };
-
   const tt = [
-    realSearchIn.titleAuthor ? "1" : "",
-    realSearchIn.content ? "2" : "",
-    realSearchIn.torrent ? "3" : "",
+    searchIn.titleAuthor ? "1" : "",
+    searchIn.content ? "2" : "",
+    searchIn.torrent ? "3" : "",
   ]
     .filter(Boolean)
     .join(",");


### PR DESCRIPTION
When using the audiobookbay website search, I almost always get better results by limiting the "Search In" option in their advanced search to only the "Title & Author" field.

<img width="505" alt="image" src="https://user-images.githubusercontent.com/9214195/178346256-ac62c575-71c9-4836-9bd9-ab4397f6d05c.png">

So I thought it would be great to have that as an option in this package.  In order to keep this from being a breaking change, I made it default to using all three "Search In" options, and if you pass in the options object it will limit the search to just the ones passed.  For example:

```js
import audiobookbay from "audiobookbay";

// Instead of searching all fields, this will only search the title and author fields
const audiobooks = await audiobookbay.search("dune", 1, {
  titleAuthor: true,
});
```

Let me know if you need anything changed in order to get this pushed out!  I think this is a great package, and this is the one thing that's preventing me from using it in my project.